### PR TITLE
Update API version and include OpenAPI schemas

### DIFF
--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -17,7 +17,7 @@ spec:
               type: object
               properties:
                 datasources:
-                  description: User's email to access Grafana
+                  description: Grafana datasources
                   type: array
                   items:
                     type: object
@@ -28,7 +28,7 @@ spec:
                       data:
                         type: string
                 dashboards:
-                  description: Organizations where the user belongs
+                  description: Grafana dashboards
                   type: array
                   items:
                     type: object


### PR DESCRIPTION
- Update CRD API, current was deprecated in 1.16
- Created OpenAPI schema
- Added additional columns when listing through kubectl