### PR TITLE
Add e2e tests to the workflow

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ghcr.io
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,6 @@
-name: "RC"
+name: "Pull Request"
 
-on:
-  push:
-    tags:
-      - "v*-rc*"
+on: ["pull_request"]
 
 jobs:
   e2e:
@@ -61,29 +58,3 @@ jobs:
         run: "kubectl apply -f tests/e2e.yaml"
       - name: "Verify e2e tests"
         run: "kubectl wait --for=condition=complete --timeout=600s job/e2e"
-
-  push_to_registry:
-    name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-latest
-    needs: e2e
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-      - name: Get The Version
-        uses: battila7/get-version-action@v2
-        id: get_version
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to ghcr.io
-        uses: docker/login-action@v1 
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v2
-        with:
-          pull: true
-          no-cache: true
-          push: true
-          tags: ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,66 @@ on:
       - "v*-rc*"
 
 jobs:
+  e2e:
+    name: E2E Testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build Container Image
+        uses: docker/build-push-action@v2
+        with:
+          pull: true
+          no-cache: true
+          push: false
+          tags: ghcr.io/${{ github.repository }}:e2e
+          load: true
+
+      - name: Setup Kind
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.9.0"
+      - name: Load Container Image
+        run: kind load docker-image ghcr.io/${{ github.repository }}:e2e
+
+      - name: Install helm
+        uses: azure/setup-helm@v1
+        with:
+          version: "3.4.1"
+        id: helm_install
+      - name: Install Grafana Helm Repository
+        run: "${{ steps.helm_install.outputs.helm-path }} repo add grafana https://grafana.github.io/helm-charts --force-update"
+      - name: Update Helm Repositories
+        run: "${{ steps.helm_install.outputs.helm-path }} repo update"
+
+
+      - name: Setup Grafana
+        run: "${{ steps.helm_install.outputs.helm-path }} upgrade --install grafana --set adminPassword=admin grafana/grafana"
+      - name: Wait for Grafana
+        run: "kubectl wait --for=condition=available --timeout=600s deployment/grafana"
+
+      - name: Setup Grafana Multi-Tenant Operator (Configuration)
+        run: "kubectl create secret generic grafana-multi-tenant-operator --from-literal=GRAFANA_MULTI_TENANT_OPERATOR_HOST=grafana.default.svc.cluster.local --from-literal=GRAFANA_MULTI_TENANT_OPERATOR_ADMIN_USERNAME=admin --from-literal=GRAFANA_MULTI_TENANT_OPERATOR_ADMIN_PASSWORD=admin"
+      - name: Setup Grafana Multi-Tenant Operator
+        run: "${{ steps.helm_install.outputs.helm-path }} upgrade --install k8spin --set image.tag=e2e deploy/charts/grafana-multi-tenant-operator"
+      - name: Wait for Grafana Multi-Tenant Operator
+        run: "kubectl wait --for=condition=available --timeout=600s deployment/k8spin-grafana-multi-tenant-operator"
+
+      - name: "Deploy examples"
+        run: "kubectl apply -f examples/"
+
+      - name: "Run e2e tests"
+        run: "kubectl apply -f tests/e2e.yaml"
+      - name: "Verify e2e tests"
+        run: "kubectl wait --for=condition=complete --timeout=600s job/e2e"
+
   push_to_registry:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
+    needs: e2e
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,47 @@
+# E2E Tests
+
+Follow this guide to run e2e tests locally:
+
+## Manual
+
+First, create a local kind cluster:
+
+```bash
+$ kind create cluster
+```
+
+Then build and deploy the operator:
+
+```bash
+$ docker build -t ghcr.io/k8spin/grafana-multi-tenant-operator:e2e .
+$ kind load docker-image ghcr.io/k8spin/grafana-multi-tenant-operator:e2e
+$ helm repo add grafana https://grafana.github.io/helm-charts --force-update
+$ helm repo update
+$ helm upgrade --install grafana --set adminPassword=admin grafana/grafana
+$ kubectl wait --for=condition=available --timeout=600s deployment/grafana
+$ kubectl create secret generic grafana-multi-tenant-operator --from-literal=GRAFANA_MULTI_TENANT_OPERATOR_HOST=grafana.default.svc.cluster.local --from-literal=GRAFANA_MULTI_TENANT_OPERATOR_ADMIN_USERNAME=admin --from-literal=GRAFANA_MULTI_TENANT_OPERATOR_ADMIN_PASSWORD=admin
+$ helm upgrade --install k8spin --set image.tag=e2e deploy/charts/grafana-multi-tenant-operator
+$ kubectl wait --for=condition=available --timeout=600s deployment/k8spin-grafana-multi-tenant-operator
+```
+
+Deploy a few examples then run e2e tests:
+
+```bash
+$ kubectl apply -f examples/
+$ kubectl apply -f tests/e2e.yaml
+$ kubectl wait --for=condition=complete --timeout=600s job/e2e
+```
+
+Teardown the local cluster:
+
+```bash
+$ kind delete cluster
+```
+
+## Script
+
+All these commands are available in a single bash script.
+
+```bash
+$ ./tests/local.sh
+```

--- a/tests/e2e.yaml
+++ b/tests/e2e.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: e2e
+spec:
+  template:
+    spec:
+      containers:
+      - name: e2e-org
+        image: alpine
+        command: ["/bin/sh",  "-c"]
+        args: ["apk add -q --no-cache curl && curl -s \"http://admin:admin@grafana/api/orgs?perpage=10\" | grep example.com"]
+      - name: e2e-user
+        image: alpine
+        command: ["/bin/sh",  "-c"]
+        args: ["apk add -q --no-cache curl && curl -s \"http://admin:admin@grafana/api/users?perpage=10\" | grep \"jhon-doe\""]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/local.sh
+++ b/tests/local.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Create kind cluster"
+kind create cluster
+
+echo "Build and deploy to kind the operator"
+docker build -t ghcr.io/k8spin/grafana-multi-tenant-operator:e2e .
+kind load docker-image ghcr.io/k8spin/grafana-multi-tenant-operator:e2e
+
+echo "Deploy Grafana Server"
+helm repo add grafana https://grafana.github.io/helm-charts --force-update
+helm repo update
+helm upgrade --install grafana --set adminPassword=admin grafana/grafana
+kubectl wait --for=condition=available --timeout=600s deployment/grafana
+
+echo "Deploy Grafana Multi-Tenant Operator"
+kubectl create secret generic grafana-multi-tenant-operator --from-literal=GRAFANA_MULTI_TENANT_OPERATOR_HOST=grafana.default.svc.cluster.local --from-literal=GRAFANA_MULTI_TENANT_OPERATOR_ADMIN_USERNAME=admin --from-literal=GRAFANA_MULTI_TENANT_OPERATOR_ADMIN_PASSWORD=admin
+helm upgrade --install k8spin --set image.tag=e2e deploy/charts/grafana-multi-tenant-operator
+kubectl wait --for=condition=available --timeout=600s deployment/k8spin-grafana-multi-tenant-operator
+
+echo "Deploy examples"
+kubectl apply -f examples/
+
+echo "Deploy e2e tests"
+kubectl apply -f tests/e2e.yaml
+kubectl wait --for=condition=complete --timeout=120s job/e2e
+
+echo "Delete local Cluster"
+kind delete cluster


### PR DESCRIPTION
With this PR a new job is included along with another workflow.

It prevents to release stuff if the e2e tests doesn't work.

E2E are triggered once:
- On pull requests events
- On release candidates tags
- On release tags

I've included a script to run it locally.