### PR TITLE
Adding support for optional title in Dashboard CRD

### DIFF
--- a/deploy/charts/grafana-multi-tenant-operator/crds/crd-grafana-dashboard.yaml
+++ b/deploy/charts/grafana-multi-tenant-operator/crds/crd-grafana-dashboard.yaml
@@ -38,6 +38,8 @@ spec:
                   properties:
                     name:
                       type: string
+                    title:
+                      type: string
                     data:
                       type: string
                 organizations:

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -160,6 +160,8 @@ spec:
                   properties:
                     name:
                       type: string
+                    title:
+                      type: string
                     data:
                       type: string
                 organizations:

--- a/examples/example.com-grafana-dashboard-with-title.yaml
+++ b/examples/example.com-grafana-dashboard-with-title.yaml
@@ -1,0 +1,141 @@
+apiVersion: grafana.k8spin.cloud/v1
+kind: Dashboard
+metadata:
+  name: my-other-unique-dashboard
+spec:
+  organizations:
+  - example.com
+  dashboard:
+    name: my-other-unique-dashboard
+    title: "Best Dashboard in the World"
+    data: |-
+      {
+        "annotations": {
+          "list": [
+            {
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "type": "dashboard"
+            }
+          ]
+        },
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "id": 1,
+        "links": [],
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 9,
+              "w": 12,
+              "x": 0,
+              "y": 0
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+              "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "queryType": "randomWalk",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Panel Title",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "schemaVersion": 26,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+          "list": []
+        },
+        "time": {
+          "from": "now-6h",
+          "to": "now"
+        },
+        "timepicker": {},
+        "timezone": "",
+        "title": "MyDashboard",
+        "uid": "BIrxFSJMz",
+        "version": 1
+      }

--- a/grafana/dashboard.py
+++ b/grafana/dashboard.py
@@ -1,7 +1,7 @@
 from grafana import MAIN_ORG_ID, GrafanaException, organization
 
 
-async def create(api, name, jsonDashboard, organizationNames, lock, logger):
+async def create(api, name, title, jsonDashboard, organizationNames, lock, logger):
     responses = []
     orgIds = []
     try:
@@ -16,7 +16,7 @@ async def create(api, name, jsonDashboard, organizationNames, lock, logger):
             try:
                 api.organizations.switch_organization(orgId)
                 jsonDashboard['uid'] = name
-                jsonDashboard['title'] = name
+                jsonDashboard['title'] = title if title else name
                 del jsonDashboard['id']
                 dashboard_object = {
                     'dashboard': jsonDashboard,
@@ -34,7 +34,7 @@ async def create(api, name, jsonDashboard, organizationNames, lock, logger):
     return responses
 
 
-async def update(api, oldName, newName, oldOrganizationNames, newOrganizationNames, jsonDashboard, lock, logger):
+async def update(api, oldName, newName, newTitle, oldOrganizationNames, newOrganizationNames, jsonDashboard, lock, logger):
     responses = []
     # Delete dashboards from organizations it doesn't belong
     pruneOrgs = [
@@ -86,6 +86,7 @@ async def update(api, oldName, newName, oldOrganizationNames, newOrganizationNam
             jsonDashboard['id'] = None
             # Setting the uid to the resource name, to be able to find it later
             jsonDashboard['uid'] = newName
+            jsonDashboard['title'] = newTitle if newTitle else newName
             dashboard_object = {
                 'dashboard': jsonDashboard,
                 'folderId': 0,

--- a/handler.py
+++ b/handler.py
@@ -64,9 +64,10 @@ def delete_user(status, **kwargs):
 @kopf.on.create('grafana.k8spin.cloud', 'v1', 'dashboards')
 async def create_dashboard(spec, logger, **kwargs):
     name = spec.get('dashboard').get('name')
+    title = spec.get('dashboard').get('title')
     dash = json.loads(spec.get('dashboard').get('data'))
     organizationNames = spec.get('organizations', list())
-    responses = await dashboard.create(api, name, dash, organizationNames, ORG_SWITCH_LOCK, logger)
+    responses = await dashboard.create(api, name, title, dash, organizationNames, ORG_SWITCH_LOCK, logger)
     if not responses:
         raise kopf.TemporaryError("Could not create dashboard yet.", delay=10)
     return responses
@@ -76,10 +77,11 @@ async def create_dashboard(spec, logger, **kwargs):
 async def update_dashboard(status, old, new, logger, **kwargs):
     oldName = old.get('spec').get('dashboard').get('name')
     newName = new.get('spec').get('dashboard').get('name')
+    newTitle = new.get('spec').get('dashboard').get('title')
     oldOrganizationNames = old.get('spec').get('organizations', list())
     newOrganizationNames = new.get('spec').get('organizations', list())
     newDashboard = json.loads(new.get('spec').get('dashboard').get('data'))
-    responses = await dashboard.update(api, oldName, newName, oldOrganizationNames, newOrganizationNames, newDashboard, ORG_SWITCH_LOCK, logger)
+    responses = await dashboard.update(api, oldName, newName, newTitle, oldOrganizationNames, newOrganizationNames, newDashboard, ORG_SWITCH_LOCK, logger)
     if not responses:
         raise kopf.TemporaryError("Could not update dashboard yet.", delay=10)
     return responses

--- a/tests/e2e.yaml
+++ b/tests/e2e.yaml
@@ -20,5 +20,10 @@ spec:
         command: ["/bin/sh",  "-c"]
         args:
         - "apk add -q --no-cache jq curl && curl -s 'http://admin:admin@grafana/api/orgs/name/example.com' | jq '.id' | xargs -I {} curl -XPOST -s -o /dev/null 'http://admin:admin@grafana/api/user/using/{}' | curl -XGET -s 'http://admin:admin@grafana/api/search' | jq -r '.[].uid' | grep -q unique-dashboard-name && test $? -eq 0"
+      - name: e2e-dashboard-with-title
+        image: alpine
+        command: ["/bin/sh",  "-c"]
+        args:
+        - "apk add -q --no-cache jq curl && curl -s 'http://admin:admin@grafana/api/orgs/name/example.com' | jq '.id' | xargs -I {} curl -XPOST -s -o /dev/null 'http://admin:admin@grafana/api/user/using/{}' | curl -XGET -s 'http://admin:admin@grafana/api/search' | jq -r '.[].title' | grep -q 'Best Dashboard in the World' && test $? -eq 0"
       restartPolicy: Never
   backoffLimit: 25 # Higher value here instead of adding waits in the pipeline


### PR DESCRIPTION
You can add a title, optionally, to the Dashboard resource.

If `title` field not present, the dashboard custom resource will take the same name for the `uid` as the title.